### PR TITLE
add vrs-attributes flag to compute VRS start, stop, ands sequence states

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ### Description
 GA4GH VRS identifiers provide a standardized way to represent genomic variations, making it easier to exchange, harmonize, and integrate genomic information. 
 
-This WDL workflow provides a way for you to annotate Variant Call Format (VCF) files with GA4GH Variation Representation Specification (VRS) Allele IDs! This makes integration of genomic variant data with downstream evidence data like [MetaKB](https://search.cancervariants.org/) much easier.
+This WDL workflow wraps the functionality of vrs-python's [vcf_annotator](https://github.com/ga4gh/vrs-python/blob/main/docs/extras/vcf_annotator.md), allowing you to annotate Variant Call Format (VCF) files with GA4GH Variation Representation Specification (VRS) Allele IDs on Terra! This makes integration of genomic variant data with downstream evidence data like [MetaKB](https://search.cancervariants.org/) much easier.
 
 To get started, navigate to the [VRS AnVIL](https://app.terra.bio/#workspaces/terra-test-bwalsh/vrs_anvil_toolkit) workspace to run it on Terra! For more details, see the docs on [setting up a Terra workflow](https://support.terra.bio/hc/en-us/articles/360036379771-Overview-Running-workflows-in-Terra) and the Dockstore repository for the [VRS Annotator workflow](https://dockstore.org/my-workflows/github.com/ohsu-comp-bio/vrs-annotator/VRSAnnotator).
 
@@ -12,4 +12,5 @@ To get started, navigate to the [VRS AnVIL](https://app.terra.bio/#workspaces/te
 - `output_vcf_name` (String): Name of annotated VCF file with its file extension (vcf.gz)
 - `seqrepo_tarball` (File, optional): Google resource path for seqrepo tarball (tar.gz). Defaults to tarball stored in the requestor pays VRS AnVIL Workspace.
 - `compute_for_ref` (boolean, optional): Whether to compute both the ref and alt allele or compute only the alt allele for each variant. Defaults to true, computing both.
+- `vrs_attributes` (boolean, optional): Whether to compute both the ref and alt allele or compute only the alt allele for each variant. Defaults to true, computing both.
 - `genome_assembly` (String, optional): genome assembly or genome build used by the VCF. Defaults to "GRCh38", but "GRCh37" is also supported.

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -63,9 +63,9 @@ task annotate {
 
         # add runtime flags
         if ~{compute_for_ref}; then
-            REF_FLAG="--skip_ref" && ~{compute_for_ref}
-        else
             REF_FLAG=""
+        else
+            REF_FLAG="--skip_ref"
         fi
         
         if ~{compute_vrs_attributes}; then

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -61,13 +61,17 @@ task annotate {
         sudo chown "$(whoami)" $SEQREPO_DIR
         seqrepo --root-directory $SEQREPO_DIR update-latest
 
-        # add runtime flags if specified
+        # add runtime flags
         if ~{compute_for_ref}; then
-            REF_FLAG="--skip_ref"
+            REF_FLAG="--skip_ref" && ~{compute_for_ref}
+        else
+            REF_FLAG=""
         fi
         
         if ~{compute_vrs_attributes}; then
             VRS_ATTRIBUTES_FLAG="--vrs_attributes"
+        else
+            VRS_ATTRIBUTES_FLAG=""
         fi
 
         # annotate and index vcf

--- a/vrs-annotator.wdl
+++ b/vrs-annotator.wdl
@@ -17,6 +17,7 @@ workflow VRSAnnotator {
             output_vcf_name = output_vcf_name,
             seqrepo_tarball = seqrepo_tarball,
             compute_for_ref = compute_for_ref,
+            compute_vrs_attributes = compute_vrs_attributes,
             genome_assembly = genome_assembly
     }
 }
@@ -60,21 +61,23 @@ task annotate {
         sudo chown "$(whoami)" $SEQREPO_DIR
         seqrepo --root-directory $SEQREPO_DIR update-latest
 
-        # setup runtime flags
-        if not ~{compute_for_ref}:
+        # add runtime flags if specified
+        if ~{compute_for_ref}; then
             REF_FLAG="--skip_ref"
+        fi
         
-        if ~{compute_vrs_attributes}:
+        if ~{compute_vrs_attributes}; then
             VRS_ATTRIBUTES_FLAG="--vrs_attributes"
+        fi
 
         # annotate and index vcf
         python -m ga4gh.vrs.extras.vcf_annotation \
             --vcf_in ~{input_vcf_path} \
             --vcf_out ~{output_vcf_name} \
             --seqrepo_root_dir $SEQREPO_DIR/latest \
-            --assembly ~{genome_assembly}
-            ~{REF_FLAG}
-            ~{VRS_ATTRIBUTES_FLAG}
+            --assembly ~{genome_assembly} \
+            $REF_FLAG \
+            $VRS_ATTRIBUTES_FLAG
         
         bcftools index -t ~{output_vcf_name}
     >>>


### PR DESCRIPTION
**User Story**
Addresses #7

**Testing on Terra (change branch within Terra Workflow page, top left dropdown)**
✅  VRS Attributes are present in output VCF (and both ref and alt are computed) when...
 - vrs-attributes is unspecified (defaults to True)
 - vrs-attributes=True 

✅ VRS Attributes are absent in output VCF when vrs-attributes=True 

It would be great if you could test this as well on Terra to make sure it works as expected! Once we merge this, then I'll update the Terra workspace docs

**Questions**
- Do we want to also expose the rest of the flags that are accessible in vrs-python VCF Annotator or only allow `compute_for_ref`, `assembly`, and `vrs_attributes` to be specified in the workflow?
- Does it makes sense to default `vrs-attributes` to be true or should we mimic the VCF Annotator precisely?
